### PR TITLE
Makefile: add make uninstall for remove the patched WDSP from your sy…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,3 +264,7 @@ endif
 clean:
 	-rm -f *.o
 	-rm -f $(PROGRAM)
+
+uninstall: clean
+	-rm -f $(INCLUDEDIR)/wdsp.h
+	-rm -f $(LIBDIR)/$(PROGRAM)


### PR DESCRIPTION
change the `Makefile` again and add `make uninstall` convention-friendly in addition to `make clean`

73 Heiko, DL1BZ
